### PR TITLE
CASMCMS-7664 - keep the mtn ssh sessions alive.

### DIFF
--- a/scripts/ssh-console
+++ b/scripts/ssh-console
@@ -38,7 +38,7 @@ set env(TERM) xterm
 set controller [string range [lindex $argv 0] 0 end-2]
 set session [string range [lindex $argv 0] end-1 end]
 set timeout -1
-set pid [spawn ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /var/log/console/conman.key $session@$controller]
+set pid [spawn ssh -o ServerAliveInterval=180 -o ServerAliveCountMax=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /var/log/console/conman.key $session@$controller]
 exit -onexit {
   exec kill $pid
   wait $pid


### PR DESCRIPTION
### Summary and Scope
The ssh connection conman uses to do the mountain console logging will timeout where there is somewhere between 1-2 hrs of no activity.  When it reconnects to the underlying screen connection it will see the items that exist on the screen and log them as new messages.  This is confusing to have the constant re-connects and repeated messages in the console logs.

This change uses ssh options to keep pinging the ssh server to keep the connection alive.  Without the constant reconnects, the messages will not end up being repeated on a regular basis.  This should keep the connection open indefinitely.

### Issues and Related PRs
* Resolves CASMCMS-7664
* Resolves CAST-28062
* Resolves CAST-27989

### Testing
Tested on:
* Loki

Was a fresh Install tested? N - none available
Was an Upgrade tested?    N - just a script inside the pod changing.
Was a Downgrade tested?  N - just a script inside the pod changing.

I manually modified the script on the running pods on Loki then restarted the conmand process to pick up the changes.  I observed the logs over the next day and what had been resetting the connection once every hour has now gone for over 7 hours with no reconnection events.

### Risks and Mitigations

This is a low risk change.  It only adds a couple of optional arguments to the ssh connection string for mountain nodes.  It should make the logging connections more stable over longer terms.
