### PR TITLE
Refactor alpine image references

### DIFF
--- a/kubernetes/cray-console-node/Chart.yaml
+++ b/kubernetes/cray-console-node/Chart.yaml
@@ -21,5 +21,5 @@ annotations:
     - name: cray-console-node
       image: artifactory.algol60.net/csm-docker/stable/cray-console-node:0.0.0
     - name: alpine
-      image: artifactory.algol60.net/docker.io/alpine:latest
+      image: alpine:latest
   artifacthub.io/license: MIT

--- a/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
@@ -12,8 +12,8 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: hook1-container
-        image: artifactory.algol60.net/docker.io/alpine:latest
-        imagePullPolicy: IfNotPresent
+        image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
+        imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
         command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 766 /var/log']
         volumeMounts:
           - mountPath: /var/log

--- a/kubernetes/cray-console-node/values.yaml
+++ b/kubernetes/cray-console-node/values.yaml
@@ -76,7 +76,7 @@ cray-service:
     log-forwarding:
       name: log-forwarding
       image:
-        repository: artifactory.algol60.net/docker.io/alpine
+        repository: alpine
         tag: latest
       args: [/bin/sh, -c, 'tail -n 0 -F /tmp/consoleAgg/consoleAgg-${MY_POD_NAME}.log']
       env:
@@ -113,3 +113,9 @@ cray-service:
     prefix: /apis/console-node
   strategy:
     type: Recreate
+
+alpine:
+  image:
+    repository: alpine
+    tag: latest
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Add `alpine.image` settings to values.yaml in order to enable customization.

Change default alpine reference from `artifactory.algol60.net/docker.io/alpine:latest` to `alpine:latest`. Chart defaults should reference upstream locations instead of registry mirrors.

Supplements [CASMCMS-7695](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7695). Required to resolve [CASM-2670](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2670).