### PR TITLE
Change file permissions so ssh key works.

### DIFF
--- a/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
@@ -14,7 +14,7 @@ spec:
       - name: hook1-container
         image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
         imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
-        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 766 /var/log']
+        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 700 /var/log']
         volumeMounts:
           - mountPath: /var/log
             name: cray-console-logs


### PR DESCRIPTION
## Summary and Scope

The post-upgrade hook was setting a permission level that didn't work with the ssh key for mountain console connections.  The ssh key needs to be private to the current user or the ssh connection will fail.  This level of permission works for all files on the /var/log mount, so I just changed the hook to set this same permission on all log files.  They will all be read/write accessible for the user the container is started under.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2915](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2915)
* Change will also be needed in `https://github.com/Cray-HPE/console-operator`

## Testing
### Tested on:
  * `Hela`

### Test description:

The file permissions had manually been changed to '700' to make the ssh connections work.  I restored the permissions to '766' and verified the ssh connections were not working.  I manually changed all the file permissions under '/var/log' to '700' and restarted the conmand process.  I then verified interactive consoles work correctly and the log files were being generated correctly.  Setting this permission on all files and directories is valid. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N - doesn't cover this
- Were continuous integration tests run? If not, why? N - doesn't cover this
- Was upgrade tested? If not, why? N - System availability
- Was downgrade tested? If not, why? N - System availability
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a low risk change as the permissions are the same for the user the container is running under.  The only other user with any active process is 'root' which will not run into permission issues.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
