### PR TITLE
CASMCMS-7786: Move to SLES15SP3 to avoid CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,13 @@
 # Dockerfile for cray-console-node service
 
 # Build will be where we build the go binary
-FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2 as build
+FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp3:sles15sp3 as build
+
+# The current sles15sp3 base image starts with a lock on coreutils, but this prevents a necessary
+# security patch from being applied. Thus, adding this command to remove the lock if it is
+# present.
+RUN zypper --non-interactive removelock coreutils || true
+
 RUN set -eux \
     && zypper --non-interactive install go1.14
 
@@ -47,7 +53,12 @@ RUN set -ex && go build -v -i -o /app/console_node $GOPATH/src/console_node
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2 as base
+FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp3:sles15sp3 as base
+
+# The current sles15sp3 base image starts with a lock on coreutils, but this prevents a necessary
+# security patch from being applied. Thus, adding this command to remove the lock if it is
+# present.
+RUN zypper --non-interactive removelock coreutils || true
 
 # Install conman application from package
 RUN set -eux \


### PR DESCRIPTION
## Summary and Scope

Build the console-node container with SP3 as the base image instead of SP2, to avoid a CVE. No other changes.

## Issues and Related PRs

[CASM-2794](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2794) / [CASMCMS-7787](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7787)  The new cray-console-node image also addresses this CVE

## Testing

On mug I applied the new console-node and ran the barebones boot test. I was able to watch the compute node console using the new console-node pod with no problems.

## Risks and Mitigations

I think this is low risk. Going from a base image of SP2 to SP3 should not affect how conman works.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
