### PR TITLE
Remove polkit from image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,10 @@ RUN zypper --non-interactive removelock coreutils || true
 RUN set -eux \
     && zypper --non-interactive install conman less vi openssh jq curl tar
 
+# NOTE: polkit is not needed but is included with one of the above packages.
+#  It has frequent security issues so just remove it here.
+RUN zypper --non-interactive rm polkit
+
 # Apply security patches
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh


### PR DESCRIPTION
## Summary and Scope

Remove the 'polkit' package from the published image.  This package is installed as part of the 'vi' zypper install but is not required by any of the basic functions of the services.  Furthermore it frequently has CVE vulnerabilities that require patching.  In an effort to improve the long term security of this service, this package is being deliberately removed from the image.  As it is not required, it has no impact on the running of this service. 

## Issues and Related PRs

* Resolves [CASMCMS-7793](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7793)

## Testing
### Tested on:
  * Mug

### Test description:

I did a Helm install/upgrade of the new image on Mug.  When the new version was up and running I confirmed the basic operations of the service (interactive console access and logging) was working correctly.  I then did a Helm rollback to restore the original installed version of cray-console-node and insured all was again working correctly.

- Were the install/upgrade-based validation checks/tests run: N - manually verified and tests are basic.
- Were continuous integration tests run? N - not covered
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N - no new functionality added.

## Risks and Mitigations
As this package was not added in support of any required functionality, removal should not impact the functioning of this service.  This should have very minimal risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

