### PR TITLE
CASMCMS-8055 - add anti-affinity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+ - CASMCMS-8055 - add pod anti-affinity to helm chart.
 
 [1.0.0] - (no date)

--- a/kubernetes/cray-console-node/values.yaml
+++ b/kubernetes/cray-console-node/values.yaml
@@ -130,6 +130,18 @@ cray-service:
       resources:
         requests:
           storage: 10Gi
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - cray-console-node
   ingress:
     enabled: true
     uri: " "


### PR DESCRIPTION
## Summary and Scope

To minimize the possibility that multiple console-node pods will be run on the same worker node, anti-affinity pod settings were added to the helm chart specification.  This will insure pods are scheduled on different workers (where able) and help the resiliency of the console services. 

## Issues and Related PRs
* Resolves [CASMCMS-8055](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8055)

## Testing
### Tested on:
  * `Drax`

### Test description:

I updated the deployment on Drax using a helm install.  When the new service was running, I deleted the pods multiple times and insured that they were never deployed on the same worker.  I then rolled back the install to the previous version and when pods were deleted they re-deployed on the same worker as other console-node pods were already running on.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - don't cover this
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a low risk change as is just provides a preference on where the pods are deployed, there are no code changes.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

