### PR TITLE
CASMCMS-7830 - migrate away from arti.dev.cray.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-
 ### Changed
+ - CASMCMS-7830: Update the base image to newer version and resolve dev.cray.com addresses.
 
 [1.0.0] - (no date)


### PR DESCRIPTION
## Summary and Scope

The dev.cray.com network domain is being retired, so update to the new location of the servers.

## Issues and Related PRs
* Resolves [CASMCMS-7830](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7830)

## Testing
### Tested on:
  * `Drax`

### Test description:

Installed via helm on Drax with the other console services.  Did complete test with flushing cached data and made sure all new services came up and operated as expected, including connecting to live console sessions on compute nodes.  Rolled back to previous installed version when complete and re-tested.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Fairly minor risk - there are no major dependencies on the base images and was completely tested on a live system.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
