### PR TITLE
CASMCMS-7830 - put back dockerfile commands to remove polkit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
- - CASMCMS-7830: Update the base image to newer version and resolve dev.cray.com addresses.
+ - CASMCMS-7830: Update the base image to newer version and resolve *.dev.cray.com addresses.
  - CASMCMS-8055: Add pod anti-affinity to helm chart.
 
 [1.0.0] - (no date)

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,10 @@ RUN zypper --non-interactive removelock coreutils || true
 RUN set -eux \
     && zypper --non-interactive install conman less vi openssh jq curl tar
 
+# NOTE: polkit is not needed but is included with one of the above packages.
+#  It has frequent security issues so just remove it here.
+RUN zypper --non-interactive rm polkit
+
 # Apply security patches
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh


### PR DESCRIPTION
## Summary and Scope

Got a little carried away cleaning up the dockerfile - put back in the code from the last PR that removes 'polkit' from the image.  It isn't needed and can expose security vulnerabilities.

Removed in: https://github.com/Cray-HPE/console-node/pull/48

## Issues and Related PRs
* Resolves [CASMCMS-7830](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7830)

## Testing
See previous PR.

## Risks and Mitigations
See previous PR.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

