### PR TITLE
CASMCMS-8016 - update hsm api to use v2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ - CASMCMS-8016: Update hsm api to v2.
 
 ## [1.4.0] - 2022-07-12
 ### Changed

--- a/kubernetes/cray-console-node/values.yaml
+++ b/kubernetes/cray-console-node/values.yaml
@@ -33,7 +33,7 @@
 console_node_config:
   cray_console_node_log_identifier: 'ID'
   cray_console_node_smd_url: 'http://cray-smd'
-  cray_console_node_rf_endpoint: 'hsm/v1/Inventory/RedfishEndpoints'
+  cray_console_node_rf_endpoint: 'hsm/v2/Inventory/RedfishEndpoints'
 
 cray-service:
   type: StatefulSet


### PR DESCRIPTION
## Summary and Scope

The hsm v1 interface is being removed from the service, so we needed to switch to using the v2 interface.  The endpoints that we are using are identical in both versions so this was a minimal change.

## Issues and Related PRs
* Resolves [CASMCMS-8016](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8016)

## Testing
### Tested on:
  * `Mug`

### Test description:

I used helm to upgrade the existing deployments of console-operator and console-node, forced a complete regeneration of the console connections, and verified the information needed is being pulled correctly from the new hsm interface and the console connections were correctly established.  I then reverted to the original versions of the services and again forced a regeneration fo the connections and verified they worked correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a required change as the v1 interface is being removed shortly.  Console services will break without this change being incorporated.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
