### PR TITLE
CASMCMS-8140 - correctly handle Hill nodes.

### DIFF
--- a/src/console_node/nodes.go
+++ b/src/console_node/nodes.go
@@ -47,6 +47,16 @@ type nodeConsoleInfo struct {
 	Role     string // role of the node
 }
 
+// Function to determine if a node is Mountain hardware
+func (node nodeConsoleInfo) isMountain() bool {
+	return node.Class == "Mountain" || node.Class == "Hill"
+}
+
+// Function to determine if a node is River hardware
+func (node nodeConsoleInfo) isRiver() bool {
+	return node.Class == "River"
+}
+
 // Provide a function to convert struct to string
 func (nc nodeConsoleInfo) String() string {
 	return fmt.Sprintf("NodeName:%s, BmcName:%s, BmcFqdn:%s, Class:%s, NID:%d, Role:%s",
@@ -113,11 +123,11 @@ func doGetNewNodes() {
 			// process the new nodes
 			for i, node := range newNodes {
 				log.Printf("  Processing node: %s", node.String())
-				if node.Class == "River" {
+				if node.isRiver() {
 					currentRvrNodes[node.NodeName] = &newNodes[i]
 					log.Printf("  Adding new river node: %s", node.String())
 					changed = true
-				} else if node.Class == "Mountain" {
+				} else if node.isMountain() {
 					currentMtnNodes[node.NodeName] = &newNodes[i]
 					log.Printf("  Adding new mtn node: %s", node.String())
 					changed = true


### PR DESCRIPTION
## Summary and Scope

In csm-1.2, hsm changed so that the 'node class' can be either 'Mountain', 'River', or 'Hill'.  The 'hill' types were not getting picked up by console services.  This set of changes looks for records containing 'Hill' and treats them correctly.

## Issues and Related PRs
* Resolves [CASMCMS-8140](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8140)

## Testing
### Tested on:

  * `Loki`

### Test description:

I installed the new version via helm and observed that Hill nodes were correctly picked up by console services and connections and logging were established.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a fairly low risk change, it just needs to handle the 'Hill' type in the existing records.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
