### PR TITLE
Add nobody user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.3] - 2023-01-13
+### Fixed
+ - Added the 'nobody' user to the image.
+ - Changed to algol60 base image, which is routinely updated, to help resolve CVE's.
+
+## [1.6.2] - 2023-01-10
 ### Changed
  - CASMCMS-8252: Enabled building of unstable artifacts
  - CASMCMS-8252: Updated header of update_versions.conf to reflect new tool options


### PR DESCRIPTION
## Summary and Scope

Add 'nobody' user. For an unknown reason, the SLES15SP3 image we get from the algol60 artifactory does not have the 'nobody' user present in it. This adds it.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8353

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * 'Shandy'

### Test description:

I built the image and uploaded it to Shandy. I relaunched the cray-console-node statefulset using this new Docker image. I exec'd into one statefulset and saw that the 'nobody' user existed and that I could interactively connect to a node.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

