### PR TITLE
CASMINST-5878 - remove post-install hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [1.7.2] - 2023-2-2
+### Changed
+- CASMINST-5878: Remove post-install hook that depends on console-operator PVC.
+
 ## [1.7.1] - 2022-12-20
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,8 @@ metadata:
   name: console-node-post-upgrade
   namespace: "services"
   annotations:
-    "helm.sh/hook": post-upgrade,post-install
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed,
 spec:
   template:
     spec:


### PR DESCRIPTION
## Summary and Scope

This hook is working on a PVC that is created by the console-operator helm chart. If this chart is deployed before the operator chart, the hook will fail since that PVC isn't created yet. Do not run the hook on an install, just an upgrade since the upgrade case should have the operator already deployed hence the PVC will exist.

I also added a condition to delete the hook job when complete no matter what. The presence of the hook job can keep a handle on the PVC and not allow it to be removed when uninstalling the chart.

## Issues and Related PRs

* Resolves [CASMINST-5878](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5878)

## Testing
### Tested on:
  * `Fanta`
  * Local development environment
  * Virtual Shasta

### Test description:

I did helm install/uninstall/upgrade operations in every order I could think of, including with the cray-console-operator chart to insure everything works as it is supposed to.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as just working with helm hooks and I tested all possible combinations.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

