### PR TITLE
CASMCMS-7169: Add new thread to check for passwords/creds changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - CASMCMS-8252: Enabled building of unstable artifacts
  - CASMCMS-8252: Updated header of update_versions.conf to reflect new tool options
+ - CASMCMS-7169: Conman will be restarted if there is a change to the credentials
 
 ### Fixed
  - CASMCMS-8252: Update Chart with correct image and chart version strings during builds.

--- a/src/console_node/conman.go
+++ b/src/console_node/conman.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -289,6 +289,7 @@ func updateConfigFile(forceUpdate bool) {
 	// NOTE: sometimes if vault hasn't been populated yet there may be no
 	// return values - try again for a while in that case.
 	passwords := getPasswordsWithRetries(rvrXNames, 15, 10)
+	previousPasswords = passwords
 
 	// Add River endpoints to the config file to be accessed by ipmi
 	for _, nodeCi := range currentRvrNodes {

--- a/src/console_node/consoleNodeMain.go
+++ b/src/console_node/consoleNodeMain.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -139,6 +139,9 @@ func main() {
 
 	// start up the thread that runs conman
 	go runConman()
+
+	// start up the thread to monitor for configuration changes
+	go doMonitor()
 
 	// set up mechanism to test for killing tail functions
 	if debugOnly {

--- a/src/console_node/monitor.go
+++ b/src/console_node/monitor.go
@@ -1,0 +1,167 @@
+//
+//  MIT License
+//
+//  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// This file contains the functions to monitor for changes in keys and certs
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	compcreds "github.com/Cray-HPE/hms-compcredentials"
+)
+
+// Time to wait between checking for credential changes
+var monitorIntervalSecs int = 30
+
+var previousPrivateKeyHash []byte = nil
+var previousPublicKeyHash []byte = nil
+
+var previousPasswords map[string]compcreds.CompCredentials = nil
+
+// function to do check for credential changes and restart conman if necessary
+func checkForChanges() {
+	restartConman := false
+
+	// check for changes in the mountain key files
+	if checkIfMountainConsoleKeysChanged() {
+		restartConman = true
+	}
+
+	// check for changes in river keys
+	if checkIfRiverPasswordsChanged() {
+		// the config file will be updated in the runConman thread when conman is restarted
+		restartConman = true
+	}
+
+	//restart conman if necessary
+	if restartConman {
+		signalConmanTERM()
+	}
+}
+
+// function to continuously monitor for changes that require conman to restart
+func doMonitor() {
+	// NOTE: this is intended to be constantly running in its own thread
+	for {
+		// do a single monitor event
+		checkForChanges()
+
+		// wait for the next interval
+		time.Sleep(time.Duration(monitorIntervalSecs) * time.Second)
+	}
+}
+
+// function to check if the passwords have changed since conman was configured
+func checkIfRiverPasswordsChanged() bool {
+	if previousPasswords == nil {
+		// this shouldn't happen due to the order of initilization, but just to be safe we skip this case.
+		return false
+	}
+
+	currNodesMutex.Lock()
+	defer currNodesMutex.Unlock()
+
+	var rvrXNames []string = nil
+	for _, nodeCi := range currentRvrNodes {
+		rvrXNames = append(rvrXNames, nodeCi.BmcName)
+	}
+	// don't retry here so we don't block heartbeats with the mutex.  we can check again the next pass
+	currentPasswords := getPasswords(rvrXNames)
+
+	for _, nodeCi := range currentRvrNodes {
+		currentCreds, ok := currentPasswords[nodeCi.BmcName]
+		if !ok {
+			log.Printf("Missing credentials detected for %s while checking for credential changes", nodeCi.BmcName)
+			continue
+		}
+		previousCreds, _ := previousPasswords[nodeCi.BmcName]
+		if (currentCreds.Username != previousCreds.Username) || (currentCreds.Password != previousCreds.Password) {
+			log.Printf("Change detected in the river passwords.  Conman will be reconfigured.")
+			return true
+		}
+	}
+	return false
+}
+
+// function to check if the console keys have changed since the last run of this function
+func checkIfMountainConsoleKeysChanged() bool {
+	var keysChanged bool = false
+
+	if len(currentMtnNodes) == 0 {
+		// if no mountain nodes are monitored, the keys don't matter
+		return false
+	}
+
+	// load hashes of both the public and private key files for comparison
+	currentPrivateKeyHash, err := hashFile(mountainConsoleKey)
+	if err != nil {
+		log.Printf("Error generating a hash of the private console key: %s", err)
+		return false
+	}
+	currentPublicKeyHash, err := hashFile(mountainConsoleKeyPub)
+	if err != nil {
+		log.Printf("Error generating a hash of the public console key: %s", err)
+		return false
+	}
+
+	// don't register a change if this is the first time and the fields are empty
+	if previousPrivateKeyHash != nil && previousPublicKeyHash != nil {
+		// if one key changes the other should change, but this checks both for safety
+		if !(bytes.Equal(currentPrivateKeyHash, previousPrivateKeyHash)) {
+			keysChanged = true
+		}
+		if !(bytes.Equal(currentPublicKeyHash, previousPublicKeyHash)) {
+			keysChanged = true
+		}
+	}
+
+	previousPrivateKeyHash = currentPrivateKeyHash
+	previousPublicKeyHash = currentPublicKeyHash
+
+	if keysChanged {
+		log.Printf("Change detected in the mountain keys.  Conman will be restarted.")
+	}
+	return keysChanged
+}
+
+// returns a hash of the given file
+func hashFile(fileName string) ([]byte, error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return nil, err
+	}
+	return hasher.Sum(nil), nil
+}


### PR DESCRIPTION
## Summary and Scope

Adds a new routine that regularly checks for new mountain/river credentials so that conman can be restarted to pick up the changes.

## Issues and Related PRs

* Resolves CASMCMS-7169

## Testing

### Tested on:

  * Surtur

### Test description:

- Tested no changes, and simulated changes for both the river and mountain credentials

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

