### PR TITLE
CASMCMS-8423 - Linting changes for new version of gofmt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.7.3] - 2023-02-24
+### Changed
+- CASMCMS-8423: Linting changes for new version of gofmt.
+
 ## [1.7.2] - 2023-2-2
 ### Changed
 - CASMINST-5878: Remove post-install hook that depends on console-operator PVC.

--- a/src/console_node/logRotation.go
+++ b/src/console_node/logRotation.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -42,10 +42,10 @@ import (
 // NOTE: the backup directory is on the shared console-operator pvc
 const logRotDir string = "/var/log/conman.old"
 
-// NOTE: the configuration and state files will be on local storage
-//  since they need to be specific for this pod, but do not need to
-//  be persisted through pod restarts.  They do need to be in locations
-//  that are writable by 'nobody' user
+// The configuration and state files will be on local storage
+// since they need to be specific for this pod, but do not need to
+// be persisted through pod restarts.  They do need to be in locations
+// that are writable by 'nobody' user
 const logRotConfFile string = "/app/logrotate.conman"
 const logRotStateFile string = "/tmp/rot_conman.state"
 


### PR DESCRIPTION
## Summary and Scope

There was a new version of 'go' installed on the image for the build pipeline. The new 'gofmt' linter objected to a couple of the comments and forced us to change them to allow the linting step to complete happily so the build would complete.

## Issues and Related PRs
* Resolves [CASMCMS-8423](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8423)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed the new version on surtur and verified the console services work correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y 
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the format of comments.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
