### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - CASMCMS-8252: Enabled building of unstable artifacts
  - CASMCMS-8252: Updated header of update_versions.conf to reflect new tool options
  - CASMCMS-7169: Conman will be restarted if there is a change to the credentials
+ - CASMCMS-7167: Implementing location api for pod location data to filter through console data
 
 ### Fixed
  - CASMCMS-8252: Update Chart with correct image and chart version strings during builds.

--- a/src/console_node/data.go
+++ b/src/console_node/data.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -46,28 +46,32 @@ var lastHeartbeatTime string = "None"
 var debugCtr int = 0
 
 // Function to acquire new consoles to monitor
-func acquireNewNodes(numMtn, numRvr int) []nodeConsoleInfo {
+func acquireNewNodes(numMtn, numRvr int, podLocation *PodLocationDataResponse) []nodeConsoleInfo {
 	// NOTE: in doGetNewNodes thread
 	log.Printf("Acquiring new nodes mtn: %d, rvr: %d", numMtn, numRvr)
-
 	// put together data package
 	type ReqData struct {
-		NumMtn int `json:"nummtn"` // Requested number of Mountain nodes
-		NumRvr int `json:"numrvr"` // Requested number of River nodes
+		NumMtn int    `json:"nummtn"` // Requested number of Mountain nodes
+		NumRvr int    `json:"numrvr"` // Requested number of River nodes
+		Alias  string `json:"alias"`  // Alias of current node pod is running on
+		Xname  string `json:"xname"`  // Xname of current node pod is running on
 	}
-	data, err := json.Marshal(ReqData{NumMtn: numMtn, NumRvr: numRvr})
+	data, err := json.Marshal(ReqData{
+		NumMtn: numMtn,
+		NumRvr: numRvr,
+		Alias:  podLocation.Alias,
+		Xname:  podLocation.Xname,
+	})
 	if err != nil {
 		log.Printf("Error marshalling data:%s", err)
 		return nil
 	}
-
 	// make the call to console-data
 	url := fmt.Sprintf("%s/consolepod/%s/acquire", dataAddrBase, podID)
 	rb, _, err := postURL(url, data, nil)
 	if err != nil {
 		log.Printf("Error in console-data acquire: %s", err)
 	}
-
 	// process the return
 	var newNodes []nodeConsoleInfo = nil
 	if rb != nil {
@@ -77,7 +81,6 @@ func acquireNewNodes(numMtn, numRvr int) []nodeConsoleInfo {
 			log.Printf("Error unmarshalling heartbeat return data: %s", err)
 		}
 	}
-
 	return newNodes
 }
 

--- a/src/console_node/nodes.go
+++ b/src/console_node/nodes.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -119,7 +119,7 @@ func doGetNewNodes() {
 			// NOTE: this should be the ONLY place where the maps of
 			//  current nodes is updated!!!
 			log.Printf("Acquiring new nodes: %d, %d", numMtn, numRvr)
-			newNodes := acquireNewNodes(numMtn, numRvr)
+			newNodes := acquireNewNodes(numMtn, numRvr, podLocData)
 			// process the new nodes
 			for i, node := range newNodes {
 				log.Printf("  Processing node: %s", node.String())

--- a/src/console_node/operator.go
+++ b/src/console_node/operator.go
@@ -1,0 +1,95 @@
+//
+//  MIT License
+//
+//  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// File contains communication with the console-operator
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+type OperatorService interface {
+	getPodLocation(podId string) (podLoc *PodLocationDataResponse, err error)
+	OperatorRetryInterval() time.Duration
+	MaxOperatorRetries() int
+}
+
+type OperatorManager struct {
+	operatorAddrBase      string
+	operatorRetryInterval time.Duration
+	maxOperatorRetries    int
+}
+
+func NewOperatorService() *OperatorManager {
+	var operatorRetryInterval time.Duration = time.Duration(30 * float64(time.Second))
+	var maxOperatorRetries int = 5
+	return &OperatorManager{
+		operatorAddrBase:      "http://cray-console-operator/console-operator/v1",
+		operatorRetryInterval: operatorRetryInterval,
+		maxOperatorRetries:    maxOperatorRetries,
+	}
+}
+
+func (om OperatorManager) OperatorRetryInterval() time.Duration {
+	return om.operatorRetryInterval
+}
+
+func (om OperatorManager) MaxOperatorRetries() int {
+	return om.maxOperatorRetries
+}
+
+type PodLocationDataResponse struct {
+	PodName string `json:"podname"`
+	Alias   string `json:"alias"`
+	Xname   string `json:"xname"`
+}
+
+func (om OperatorManager) getPodLocation(podID string) (data *PodLocationDataResponse, err error) {
+	log.Printf("Getting pod location from console-operator for pod %s\n", podID)
+	url := fmt.Sprintf("%s/location/%s", om.operatorAddrBase, podID)
+	rb, sc, err := getURL(url, nil)
+	if err != nil {
+		log.Printf("Error making GET to %s\n", url)
+		return nil, err
+	}
+
+	if sc != 200 && err == nil {
+		return nil, errors.New("failed to getPodLocation")
+	}
+
+	var resp = new(PodLocationDataResponse)
+	if rb != nil {
+		err := json.Unmarshal(rb, &resp)
+		if err != nil {
+			log.Printf("Error unmarshalling return data: %s\n", err)
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
* Location API implementation

Adds blocking retry mechanism to call the console-operator for location of the console-node.
This is dependent code requires the console-operator to be online.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

It is necessary to report the pods location so that a kubernetes pod replica should not be assigned to the hardware it is monitoring.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

This is dependent on console-operator 1.7.0 and thus not be backwards compatible with < 1.7.0.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7167
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge after https://github.com/Cray-HPE/console-operator/pull/50

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

