### PR TITLE
CASMCMS-8899 - Support Paradise nodes for console logging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8899 - add support for Paradise (xd224) nodes.
+
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -82,7 +82,8 @@ RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTI
 # Copy in the needed files
 COPY --from=build /app/console_node /app/
 COPY scripts/conman.conf /app/conman_base.conf
-COPY scripts/ssh-console /usr/bin
+COPY scripts/ssh-key-console /usr/bin
+COPY scripts/ssh-pwd-console /usr/bin
 
 # Change ownership of the app dir and switch to user 'nobody'
 RUN chown -Rv 65534:65534 /app /etc/conman.conf

--- a/scripts/ssh-key-console
+++ b/scripts/ssh-key-console
@@ -1,0 +1,47 @@
+#!/usr/bin/expect --
+
+# Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# This can be called from within the context of conman to
+# establish an ssh connection to a Mountain node console.
+# Usage and examples below assume this script's name is
+# ssh-console and located on the system under /usr/bin
+#
+# Usage: ssh-console xname
+#  Example: ssh-console x5000c3s6b0n0
+#
+# Example /etc/conman.conf entry:
+# console name="x5000c3s6b0n0" dev="/usr/bin/ssh-console x5000c3s6b0n0"
+#
+
+set env(TERM) xterm
+set controller [string range [lindex $argv 0] 0 end-2]
+set session [string range [lindex $argv 0] end-1 end]
+set timeout -1
+set pid [spawn ssh -o ServerAliveInterval=180 -o ServerAliveCountMax=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /var/log/console/conman.key $session@$controller]
+exit -onexit {
+  exec kill $pid
+  wait $pid
+  exp_exit
+}
+interact

--- a/scripts/ssh-pwd-console
+++ b/scripts/ssh-pwd-console
@@ -1,6 +1,6 @@
 #!/usr/bin/expect --
 
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,25 +23,38 @@
 # (MIT License)
 
 # This can be called from within the context of conman to
-# establish an ssh connection to a Mountain node console.
+# establish an ssh connection to a node console requiring a user name
+# and password to authenticate.
 # Usage and examples below assume this script's name is
-# ssh-console and located on the system under /usr/bin
+# ssh-pwd-console and located on the system under /usr/bin
 #
 # Usage: ssh-console xname
-#  Example: ssh-console x5000c3s6b0n0
+#  Example: ssh-pwd-console x5000c3s6b0n0 USER PASSWORD
 #
 # Example /etc/conman.conf entry:
-# console name="x5000c3s6b0n0" dev="/usr/bin/ssh-console x5000c3s6b0n0"
+# console name="x3000c0s33b4n0" dev="/app/ssh-pwd-console x3000c0s33b4 USER PASSWORD"
 #
 
 set env(TERM) xterm
-set controller [string range [lindex $argv 0] 0 end-2]
-set session [string range [lindex $argv 0] end-1 end]
+
 set timeout -1
-set pid [spawn ssh -o ServerAliveInterval=180 -o ServerAliveCountMax=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /var/log/console/conman.key $session@$controller]
+set bmc [lindex $argv 0]
+set usr [lindex $argv 1]
+set paswd [lindex $argv 2]
+
+# connect to an ssh session
+set pid [spawn ssh -p 2200 -o ServerAliveInterval=180 -o ServerAliveCountMax=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $usr@$bmc ]
+
+# reply with the password when challenged
+expect "password: "
+send -- "$paswd\r"
+
+# set up the exit condition to kill the ssh session
 exit -onexit {
   exec kill $pid
   wait $pid
   exp_exit
 }
+
+# go into interactive mode
 interact

--- a/src/console_node/consoleNodeMain.go
+++ b/src/console_node/consoleNodeMain.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -234,20 +234,20 @@ func releaseAllNodes() {
 	// gather all current nodes
 	var rn []nodeConsoleInfo
 
-	// release river nodes
-	for key, ni := range currentRvrNodes {
-		// record and stop tailing
-		rn = append(rn, *ni)
-		stopTailing(key)
+	// iterate through all nodes to stop tailing into the aggregation logs
+	allNodes := [3](*map[string]*nodeConsoleInfo){&currentRvrNodes, &currentPdsNodes, &currentMtnNodes}
+	for _, ar := range allNodes {
+		// release river nodes
+		for key, ni := range *ar {
+			// record and stop tailing
+			rn = append(rn, *ni)
+			stopTailing(key)
+		}
 	}
-	currentRvrNodes = make(map[string]*nodeConsoleInfo)
 
-	// release mtn nodes
-	for key, ni := range currentMtnNodes {
-		// record and stop tailing
-		rn = append(rn, *ni)
-		stopTailing(key)
-	}
+	// release all current node lists
+	currentRvrNodes = make(map[string]*nodeConsoleInfo)
+	currentPdsNodes = make(map[string]*nodeConsoleInfo)
 	currentMtnNodes = make(map[string]*nodeConsoleInfo)
 
 	// release the nodes from console-data

--- a/src/console_node/creds.go
+++ b/src/console_node/creds.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),

--- a/src/console_node/health.go
+++ b/src/console_node/health.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -68,8 +68,8 @@ func doHealth(w http.ResponseWriter, r *http.Request) {
 
 	var stats HealthResponse
 
-	// NOTE: just dummy it out now
-	stats.NumMtnConnected = fmt.Sprintf("%d", len(currentMtnNodes))
+	// NOTE: Paradise nodes are counted as Mountain nodes due to needing to run through an expect script
+	stats.NumMtnConnected = fmt.Sprintf("%d", len(currentMtnNodes)+len(currentPdsNodes))
 	stats.NumRvrConnected = fmt.Sprintf("%d", len(currentRvrNodes))
 	stats.TargetNumMtn = fmt.Sprintf("%d", targetMtnNodes)
 	stats.TargetNumRvr = fmt.Sprintf("%d", targetRvrNodes)
@@ -79,7 +79,6 @@ func doHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stats)
-	return
 }
 
 // Basic liveness probe
@@ -98,7 +97,6 @@ func doLiveness(w http.ResponseWriter, r *http.Request) {
 
 	// return simple StatusOK response to indicate server is alive
 	w.WriteHeader(http.StatusNoContent)
-	return
 }
 
 // Basic readiness probe
@@ -117,5 +115,4 @@ func doReadiness(w http.ResponseWriter, r *http.Request) {
 
 	// return simple StatusOK response to indicate server is alive
 	w.WriteHeader(http.StatusNoContent)
-	return
 }

--- a/src/console_node/httpUtils.go
+++ b/src/console_node/httpUtils.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -66,7 +66,7 @@ func SendResponseJSON(w http.ResponseWriter, sc int, data interface{}) {
 // Helper function to execute an http POST command
 func postURL(URL string, requestBody []byte, requestHeaders map[string]string) ([]byte, int, error) {
 	var err error = nil
-	log.Printf("postURL URL: %s\n", URL)
+	//log.Printf("postURL URL: %s\n", URL)
 	req, err := http.NewRequest("POST", URL, bytes.NewReader(requestBody))
 	if err != nil {
 		// handle error
@@ -87,7 +87,7 @@ func postURL(URL string, requestBody []byte, requestHeaders map[string]string) (
 		return nil, -1, err
 	}
 
-	log.Printf("postURL Response Status code: %d\n", resp.StatusCode)
+	//log.Printf("postURL Response Status code: %d\n", resp.StatusCode)
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -102,7 +102,7 @@ func postURL(URL string, requestBody []byte, requestHeaders map[string]string) (
 // Helper function to execute an http command
 func getURL(URL string, requestHeaders map[string]string) ([]byte, int, error) {
 	var err error = nil
-	log.Printf("getURL URL: %s\n", URL)
+	//log.Printf("getURL URL: %s\n", URL)
 	req, err := http.NewRequest("GET", URL, nil)
 	if err != nil {
 		// handle error
@@ -121,7 +121,7 @@ func getURL(URL string, requestHeaders map[string]string) ([]byte, int, error) {
 		log.Printf("getURL Error on request to %s: %s", URL, err)
 		return nil, -1, err
 	}
-	log.Printf("getURL Response Status code: %d\n", resp.StatusCode)
+	//log.Printf("getURL Response Status code: %d\n", resp.StatusCode)
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// handle error

--- a/src/console_node/logAggregation.go
+++ b/src/console_node/logAggregation.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),

--- a/src/console_node/logRotation.go
+++ b/src/console_node/logRotation.go
@@ -193,17 +193,14 @@ func updateLogRotateConf() {
 		}
 	}
 
-	// Add all the river nodes
+	// Add all nodes
 	consoleLogBackupDir := "/var/log/conman.old"
-	for xname := range currentRvrNodes {
-		fn := fmt.Sprintf("/var/log/conman/console.%s", xname)
-		writeConfigEntry(lrf, fn, consoleLogBackupDir, logRotConNumRotate, logRotConFileSize)
-	}
-
-	// Add all the mountain nodes
-	for xname := range currentMtnNodes {
-		fn := fmt.Sprintf("/var/log/conman/console.%s", xname)
-		writeConfigEntry(lrf, fn, consoleLogBackupDir, logRotConNumRotate, logRotConFileSize)
+	allNodes := [3](*map[string]*nodeConsoleInfo){&currentRvrNodes, &currentPdsNodes, &currentMtnNodes}
+	for _, ar := range allNodes {
+		for xname := range *ar {
+			fn := fmt.Sprintf("/var/log/conman/console.%s", xname)
+			writeConfigEntry(lrf, fn, consoleLogBackupDir, logRotConNumRotate, logRotConFileSize)
+		}
 	}
 
 	fmt.Fprintln(lrf, "")

--- a/src/console_node/operator.go
+++ b/src/console_node/operator.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

Paradise nodes (Cray xd224) needs to connect to the consoles through ssh but with a username and password, which is a different way of connecting than to regular river, mountain, or hill nodes. The changes in this service mostly have to do with identifying and labeling nodes that are paradise hardware.

## Issues and Related PRs
* Resolves [CASMCMS-8899](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8899)

## Testing
### Tested on:
  * `Tyr`

### Test description:

The new services were installed via helm and I manually tested that the existing mountain, hill, river, and paradise nodes all are identified correctly and the console services can connect with them.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk, but there are changes that impact the other node types as well as the new paradise nodes.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
