### PR TITLE
CASMCMS-9056 - update base image to sles15-sp5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9056 - update base image to sles15-sp5
 
 ## [2.2.1] - 2024-06-10
 ### Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,10 +23,13 @@
 #
 # Dockerfile for cray-console-node service
 
-# Build will be where we build the go binary
-FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4 as build
+# NOTE: to update to SP6, it needs to update to a newer version of 'Go', which
+#  will take a bit of work.
 
-ARG SP=4
+# Build will be where we build the go binary
+FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.5 as build
+
+ARG SP=5
 ARG ARCH=x86_64
 
 # Do zypper operations using a wrapper script, to isolate the necessary artifactory authentication
@@ -53,22 +56,22 @@ RUN set -ex \
 # NOTE:
 #  We need to switch to the below image, but for now it does not include the 'nobody' user
 #  and we need to figure out why/how that user was removed from the image.
-#FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4 as base
+#FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.5 as base
 #ARG SLES_MIRROR=https://slemaster.us.cray.com/SUSE
 #ARG ARCH=x86_64
 #RUN set -eux \
 #    && zypper --non-interactive rr --all \
-#    && zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP4/${ARCH}/product/ sles15sp4-Module-Basesystem-product \
-#    && zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP4/${ARCH}/update/ sles15sp4-Module-Basesystem-update \
-#    && zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP4/${ARCH}/product/ sles15sp4-Module-HPC-product \
-#    && zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP4/${ARCH}/update/ sles15sp4-Module-HPC-update \
+#    && zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP5/${ARCH}/product/ sles15sp5-Module-Basesystem-product \
+#    && zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP5/${ARCH}/update/ sles15sp5-Module-Basesystem-update \
+#    && zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP5/${ARCH}/product/ sles15sp5-Module-HPC-product \
+#    && zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP5/${ARCH}/update/ sles15sp5-Module-HPC-update \
 #    && zypper --non-interactive install conman less vi openssh jq curl tar
 
 ### Final Stage ###
 # Start with a fresh image so build tools are not included
-FROM arti.hpc.amslabs.hpecorp.net/baseos-docker-master-local/sles15sp4:sles15sp4 as base
+FROM arti.hpc.amslabs.hpecorp.net/baseos-docker-master-local/sles15sp5:sles15sp5 as base
 
-ARG SP=4
+ARG SP=5
 ARG ARCH=x86_64
 
 # Do zypper operations using a wrapper script, to isolate the necessary artifactory authentication


### PR DESCRIPTION
## Summary and Scope

The base image sles15-sp4 is no longer supported. To resolve some CVE's we updated to use sles15-sp5.

## Issues and Related PRs
* Resolves [CASMCMS-9056](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9056)
* Resolves [CASMPET-7114](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7114)

## Testing
### Tested on:
  * `Mug`
  * Local development environment

### Test description:

Installed the new image and verified all normal operations are still working as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as there isn't much from the base image being used.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

