### PR TITLE
CASMTRIAGE-7345 - include ps utility after sles15-sp5 upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9147 - stop using alpine:latest base image.
+- CASMTRIAGE-7345 - fix inclusion of ps utility after upgrade to sp5.
 
 ## [2.3.1] - 2024-09-05
 ### Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ COPY zypper-docker-build.sh /
 # The above script calls the following script, so we need to copy it as well
 COPY zypper-refresh-patch-clean.sh /
 RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN \
-    ./zypper-docker-build.sh conman less vi openssh jq curl tar --remove polkit && \
+    ./zypper-docker-build.sh conman less vi openssh jq curl tar procps --remove polkit && \
     rm /zypper-docker-build.sh /zypper-refresh-patch-clean.sh
 
 # Copy in the needed files

--- a/kubernetes/cray-console-node/Chart.yaml
+++ b/kubernetes/cray-console-node/Chart.yaml
@@ -44,5 +44,5 @@ annotations:
     - name: cray-console-node
       image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-console-node:0.0.0-image
     - name: alpine
-      image: alpine:latest
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3
   artifacthub.io/license: MIT

--- a/kubernetes/cray-console-node/values.yaml
+++ b/kubernetes/cray-console-node/values.yaml
@@ -99,8 +99,8 @@ cray-service:
     log-forwarding:
       name: log-forwarding
       image:
-        repository: alpine
-        tag: latest
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
+        tag: 3
       args: [/bin/sh, -c, 'tail -n 0 -F /tmp/consoleAgg/consoleAgg-${MY_POD_NAME}.log']
       env:
       - name: MY_POD_NAME
@@ -151,6 +151,6 @@ cray-service:
 
 alpine:
   image:
-    repository: alpine
-    tag: latest
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine
+    tag: 3
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

There are 2 changes being put in for this PR:

CASMTRIAGE-7345 - when the base image was updated to sp5, it no longer included the 'ps' utility by default. It had to be installed via the dockerfile. This is used by the service to track and kill zombie processes as well by users execing into the pod to restart the conmand process.

CASMCMS-9147 - replace instances of the 'alpine:latest' base image with the version we rebuild nightly to incorporate new security updates.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7345](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7345)
* Resolves [CASMCMS-9147](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9147)

## Testing
### Tested on:

  * `Fanta`

### Test description:

Installed via helm upgrade and insured that all services using the updated alpine base image are working correctly and that the 'ps' utility is once again present.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a fairly low risk change. Just re-installing a missing utility and using a different source for basically the same alpine base images.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

