### PR TITLE
CASMCMS-8681 - add inotify-tools to the base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8681 - add add inotify-tools to the base image.
 
 ## [2.4.0] - 2024-09-05
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ COPY zypper-docker-build.sh /
 # The above script calls the following script, so we need to copy it as well
 COPY zypper-refresh-patch-clean.sh /
 RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN \
-    ./zypper-docker-build.sh conman less vi openssh jq curl tar procps --remove polkit && \
+    ./zypper-docker-build.sh conman less vi openssh jq curl tar procps inotify-tools --remove polkit && \
     rm /zypper-docker-build.sh /zypper-refresh-patch-clean.sh
 
 # Copy in the needed files


### PR DESCRIPTION
## Summary and Scope

A customer has requested that the 'inotify-tools' package be added to the base image for some utilities they want to build for handling log file changes.

## Issues and Related PRs
* Resolves [CASMCMS-8681](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8681)
* Change will also be needed in `v2.3.0 branch` for hotfix to csm-1.5.x systems.

## Testing
### Tested on:
  * `drax`

### Test description:

I installed the updated package using helm to make sure that the utilities worked and the hotfix would work in a 1.5.2 context.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - just adding a utility package to the base image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

