### PR TITLE
CASMCMS-9217: Close response bodies for GET requests; ; drain and close response bodies on error path, if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMCMS-9217: Close response bodies for GET requests; drain and close response bodies on error path, if needed
 
 ## [2.5.0] - 2024-10-15
 ### Added


### PR DESCRIPTION
[CASMCMS-9214](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9214) was opened to evaluate all CMS services for potential memory leaks, specifically related to HTTP clients. CASMCMS-9217 was opened to perform this evaluation on `console-node`.

I noticed that unlike for POST requests, the corresponding GET helper function does not include a `defer` call to close the response body. This PR adds that.