### PR TITLE
v2.6.0 for CSM 1.6.n (n>=1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.0] - 2024-11-22
 ### Fixed
 - CASMCMS-9217: Close response bodies for GET requests; drain and close response bodies on error path, if needed
 


### PR DESCRIPTION
Although this small of a change normally would not merit bumping the minor number, in this case we want to do it because we are not pulling this change into CSM 1.6.0, only into CSM 1.6.1. We want to leave room to pull in critical fixes to CSM 1.6.0 if necessary, without being forced to also pull this in. Hence, the minor number bump.