### PR TITLE
CASMTRIAGE-7594 - improve node acquisition and rebalance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMTRIAGE-7594 - clean up resilience, rebalance nodes, and accept other worker nodes
+- CASMCMS-9126 - watch permissions on log files to insure they can be written to
 
 ## [2.6.0] - 2024-11-22
 ### Fixed

--- a/src/console_node/consoleNodeMain.go
+++ b/src/console_node/consoleNodeMain.go
@@ -55,6 +55,9 @@ var httpListen string = ":26776"
 // global to signify service is shutting down
 var inShutdown bool = false
 
+// global pointer to the active OperatorService
+var opService OperatorService = nil
+
 // identify what the name of this pod is
 func setPodName() {
 	// The pod name is set as an env variable by the k8s system on pod
@@ -142,10 +145,10 @@ func main() {
 	setPodName()
 
 	// Construct services
-	operatorService := NewOperatorService()
+	opService = NewOperatorService()
 
 	// Find pod location in k8s, this must block and retry
-	setPodLocation(operatorService)
+	setPodLocation(opService)
 
 	// start the aggregation log
 	respinAggLog()

--- a/src/console_node/data.go
+++ b/src/console_node/data.go
@@ -62,6 +62,36 @@ type NodeConsoleInfo struct {
 	NodeConsoleName string `json:"nodeconsolename"` // the pod console
 }
 
+// Struct to hold information about currently active node pods
+type NodePodInfo struct {
+	NumActivePods int `json:"numactivepods"`
+}
+
+// Query the console-data pod to get the number of currently active console-node pods
+func getNumActiveNodePods() (int, error) {
+	retVal := 1
+	// make the call to console-data
+	url := fmt.Sprintf("%s/activepods", dataAddrBase)
+	rb, _, err := getURL(url, nil)
+	if err != nil {
+		log.Printf("Error in console-data active pods query: %s", err)
+		return retVal, err
+	}
+
+	// process the return
+	var numPodsInfo NodePodInfo
+	if rb != nil {
+		// should be an array of nodeConsoleInfo structs
+		err := json.Unmarshal(rb, &numPodsInfo)
+		if err != nil {
+			log.Printf("Error unmarshalling active pods return data: %s", err)
+			return retVal, err
+		}
+		retVal = numPodsInfo.NumActivePods
+	}
+	return retVal, nil
+}
+
 // Function to acquire new consoles to monitor
 func acquireNewNodes(numMtn, numRvr int, podLocation *PodLocationDataResponse) []nodeConsoleInfo {
 	// NOTE: in doGetNewNodes thread


### PR DESCRIPTION
## Summary and Scope

There was a problem where a worker node's console was not being monitored by anyone because it was getting assigned/unassigned to the console-node pod that was running on that worker and the other pod didn't have capacity to pick it up. The end result was it was getting picked up and dropped continually while forcing the conmand process to keep getting killed (resulting in incomplete logging of all the nodes in that pod).

The fix was to rework how node acquisition and rebalancing happens to be much more stable and aware of the current status of the services. This fix requires changes in all three console repos.

At the same time I added a change to watch the permissions on the log files. There were problems where something was setting the files to unwritable and losing logging.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7594](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7594)
* Resolves [CASMCMS-9126](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9126)

## Testing
### Tested on:
  * `Surtur`

### Test description:

I installed all 3 new versions of the console services and monitored the node acquisition through pod rollout, then forced pod failures to insure the remaining pods picked up the orphaned nodes, then correctly rebalanced when all console-node pods were back up and running.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium size change, but I spent several days testing in all situations I could think up.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

