### PR TITLE
CASMTRIAGE-7715 - fix resetting log file permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- CASMTRIAGE-7715 - fix file permissions for log directories as well as files
 
 ## [2.7.0] - 2024-11-22
 ### Fixed

--- a/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ spec:
       - name: hook1-container
         image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
         imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
-        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 700 /var/log']
+        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 777 /var/log']
         volumeMounts:
           - mountPath: /var/log
             name: cray-console-logs


### PR DESCRIPTION
## Summary and Scope

Something has been changing the directory permissions as well as log file permissions. This looks at directories as well, and tweaks the checking logic.

## Issues and Related PRs
* Resolves [CASMTRIAGE-7715](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7715)

## Testing
### Tested on:
  * `Mug`

### Test description:

I installed the test image, then would manually change the file permissions of the log files and directories. Watching the pod log files and file/directory permissions I verified that they were set back to correctly giving read/write access.

There were a few times the node pod crashed when a file was unexpectedly read-only, but it would restart and the permissions were corrected and the restarted pod worked as expected. This should be acceptable.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a safe fix - it only tries to correct a bad situation.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

