### PR TITLE
CASMINST-7294 - fix file ownership of aggregation file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] - 2025-06-12
+### Fixed
+- CASMINST-7294 - fix file ownership for aggregation files
+
 ## [2.10.0] - 2025-05-29
 ### Fixed
 - CASMTRIAGE-8101 - fetch bmc ssh keys directly and store them on local disk

--- a/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
+++ b/kubernetes/cray-console-node/templates/hook-postupgrade.yaml
@@ -38,11 +38,16 @@ spec:
       - name: hook1-container
         image: {{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}
         imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
-        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 777 /var/log']
+        command: ['sh', '-c', 'mkdir -p /var/log/conman /var/log/conman.old /var/log/console && chown -Rv 65534:65534 /var/log && chmod -R 777 /var/log && chown -Rv 65534:65534 /tmp/consoleAgg']
         volumeMounts:
           - mountPath: /var/log
             name: cray-console-logs
+          - mountPath: /tmp/consoleAgg
+            name: cray-console-node-agg
       volumes:
         - name: cray-console-logs
           persistentVolumeClaim:
             claimName: cray-console-operator-data-claim
+        - name: cray-console-node-agg
+          persistentVolumeClaim:
+            claimName: cray-console-node-agg-data-claim


### PR DESCRIPTION
## Summary and Scope

I found a case with rocket where it has been upgraded since csm-0.9.x. When we made the change from running as 'root' to running as 'nobody' there were files created owned by the user 'root' that the 'nobody' user was not able to accesss.

This was not seen in systems with a fresh install - this is only due to the continual upgrades.

This fix just changes the ownership of those existing files. In most systems it will be a no-op, but in the case where the files have the wrong owner from an old install, this will resolve the issue.

## Issues and Related PRs
* Resolves [CASMINST-7294](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7294)

## Testing
### Tested on:
  * `Rocket`

### Test description:

I installed the updated system on rocket where this was observed via helm. I verified the files ownership was corrected and the system works correctly now.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - should be a no-op for most systems.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

